### PR TITLE
Allow the use of mode_t defined elsewhere (ACE)

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -199,6 +199,12 @@ Currently the following symbols exist:
 @itemdef{wxHAS_RAW_KEY_CODES, Defined if raw key codes (see wxKeyEvent::GetRawKeyCode are supported.}
 @itemdef{wxHAS_REGEX_ADVANCED, Defined if advanced syntax is available in wxRegEx.}
 @itemdef{wxHAS_TASK_BAR_ICON, Defined if wxTaskBarIcon is available on the current platform.}
+@itemdef{wxHAS_NO_MODE_T, Defined when we need to link with another library
+    that also defines mode_t (http://www.cs.wustl.edu/~schmidt/ACE.html).
+    wxWidgets defines mode_t when __VISUALC__ is defined. It is required to
+    #include the definition where mode_t is defined within the other library
+    (#include "ace/os_include/sys/os_types.h") before any #include of wxWidgets
+    in all source file.}
 @endDefList
 
 

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -44,7 +44,7 @@
 // constants
 // ----------------------------------------------------------------------------
 
-#if defined(__VISUALC__)
+#if defined(__VISUALC__) && !defined(WX_HIDE_MODE_T)
     typedef int mode_t;
 #endif
 

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -44,7 +44,7 @@
 // constants
 // ----------------------------------------------------------------------------
 
-#if defined(__VISUALC__) && !defined(WX_HIDE_MODE_T)
+#if defined(__VISUALC__) && !defined(wxHAS_NO_MODE_T)
     typedef int mode_t;
 #endif
 


### PR DESCRIPTION
In Linux, 'mode_t' is a 'typdef' defined in types.h. In Windows, there is no
such definition. That's why wxWidgets defines it in filefn.h when building
with VC compiler.

However, when we use both wxWidgets and ACE libraries within a common project
targeted for Windows, there is a conflct because ACE also declares 'mode_t'.

To remedy this situation we need to recompile wxWidgets with this patch
on include/wx/filefn.h:


-#if defined(__VISUALC__)
+#if defined(__VISUALC__) && !defined(WX_HIDE_MODE_T)
     typedef in
[filefn.patch.zip](https://github.com/htalbot/wxWidgets/files/76226/filefn.patch.zip)
t mode_t;
 #endif


Thus, when we mix wxWidgets and ACE (TAO/OpenDDS), we declare the macro
WX_HIDE_MODE_T in the project and we use #include "ace/os_include/sys/os_types.h"
before the first #include of wxWidgets in the source file. When we build a module
linking with wxWidgets alone, there is no need to define any additional macro in
the project.

